### PR TITLE
More CRUD and front-end fixes

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -7,6 +7,8 @@ use App\Http\Requests\ProjectUpdateRequest;
 use App\Http\Resources\ProjectResource;
 use App\Models\Project;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\JsonResponse;
+use Exception;
 
 class ProjectController extends Controller
 {
@@ -29,5 +31,23 @@ class ProjectController extends Controller
         $project->update($request->validated());
 
         return new ProjectResource($project);
+    }
+
+    public function destroy(Project $project): JsonResponse
+    {
+        try {
+            $project->delete();
+
+            return response()->json([
+                'message' => 'Project deleted successfully.',
+                'status' => 'success',
+            ], 200);
+        } catch (Exception $e) {
+            return response()->json([
+                'message' => 'Failed to delete the project.',
+                'status' => 'error',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
     }
 }

--- a/database/migrations/2024_11_22_121446_create_tasks_table.php
+++ b/database/migrations/2024_11_22_121446_create_tasks_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('tasks', function (Blueprint $table) {
@@ -18,13 +15,10 @@ return new class extends Migration
             $table->dateTime('due_date');
             $table->timestamps();
 
-            $table->foreign('project_id')->references('id')->on('projects');
+            $table->foreign('project_id')->references('id')->on('projects')->onDelete('cascade');;
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::dropIfExists('tasks');

--- a/resources/js/components/Projects.vue
+++ b/resources/js/components/Projects.vue
@@ -9,12 +9,19 @@
                     v-model="name"
                     name="name"
                 >
+                <div v-if="errors" class="flex">
+                    <p
+                        v-for="error in errors.name"
+                        :key="error"
+                        class="text-red-600"
+                    >
+                        {{ error }}
+                    </p>
+                </div>
 
                 <button
                     type="button"
                     @click="storeProject"
-                    disabled
-                    title="This feature is under development"
                 >
                     Save project
                 </button>
@@ -31,16 +38,31 @@
 </template>
 
 <script>
+import axios from 'axios';
+
 export default {
     name: 'projects',
     data() {
         return {
             name: '',
+            errors: [],
         };
     },
     methods: {
         storeProject() {
-            // TODO: Add storing logic
+            const data = {
+                name: this.name
+            };
+
+            axios.post('/projects', data)
+            .then(() => {
+                this.errors = [];
+                alert('The project was successfully created.');
+                this.$router.push({ path: '/reports' });
+            })
+            .catch(error => {
+                this.errors = error.response.data.errors;
+            });
         }
     }
 }

--- a/resources/js/components/Reports.vue
+++ b/resources/js/components/Reports.vue
@@ -75,7 +75,18 @@ export default {
                 });
         },
         editProject() {},
-        deleteProject() {},
+        deleteProject(projectId) {
+            axios
+                .delete(`/projects/${projectId}`)
+                .then(response => {
+                    this.projects = this.projects.filter(project => project.id !== projectId);
+                    alert(response.data.message);
+                })
+                .catch(error => {
+                    console.error('Error:', error.response.data.message);
+                    alert('Failed to delete the project.');
+                });
+        },
     }
 }
 </script>

--- a/resources/js/components/Reports.vue
+++ b/resources/js/components/Reports.vue
@@ -74,6 +74,7 @@ export default {
                     console.error("There was an error fetching the projects data:", error);
                 });
         },
+        // TODO: Fix edit logic
         editProject() {},
         deleteProject(projectId) {
             axios

--- a/resources/js/components/Reports.vue
+++ b/resources/js/components/Reports.vue
@@ -1,13 +1,14 @@
 <template>
     <div class="w-1/2 border-2 border-black m-auto p-4">
         <div>
-            <h3 class="flex justify-center">Projects List</h3>
+            <h3 class="flex justify-center">Project List</h3>
             <table v-if="projects.length">
                 <thead>
                     <tr>
-                        <th>Project ID</th>
+                        <th>ID</th>
                         <th>Project name</th>
                         <th>Tasks</th>
+                        <th>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -16,6 +17,22 @@
                         <td>{{ project.name }}</td>
                         <td>
                             {{ project.tasks.map(task => task.name).join(', ') }}
+                        </td>
+                        <td>
+                            <div class="flex">
+                                <button
+                                    class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-1 px-3 mr-2"
+                                    @click="editProject(project)"
+                                >
+                                    Edit
+                                </button>
+                                <button
+                                    class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3"
+                                    @click="deleteProject(project.id)"
+                                >
+                                    Delete
+                                </button>
+                            </div>
                         </td>
                     </tr>
                 </tbody>
@@ -56,7 +73,9 @@ export default {
                 .catch(error => {
                     console.error("There was an error fetching the projects data:", error);
                 });
-        }
+        },
+        editProject() {},
+        deleteProject() {},
     }
 }
 </script>

--- a/resources/js/components/Tasks.vue
+++ b/resources/js/components/Tasks.vue
@@ -9,6 +9,15 @@
                     {{ project.name }}
                 </option>
             </select>
+            <div v-if="errors" class="flex">
+                <p
+                    v-for="error in errors.project_id"
+                    :key="error"
+                    class="text-red-600"
+                >
+                    {{ error }}
+                </p>
+            </div>
 
             <label for="name">Name</label>
             <input
@@ -17,15 +26,31 @@
                 v-model="name"
                 name="name"
             >
+            <div v-if="errors" class="flex">
+                <p
+                    v-for="error in errors.name"
+                    :key="error"
+                    class="text-red-600"
+                >
+                    {{ error }}
+                </p>
+            </div>
 
             <label for="datetime">Choose a date and time:</label>
-            <input type="datetime-local" id="datetime" name="datetime">
+            <input type="datetime-local" id="datetime" name="datetime" v-model="dueDate">
+            <div v-if="errors" class="flex">
+                <p
+                    v-for="error in errors.due_date"
+                    :key="error"
+                    class="text-red-600"
+                >
+                    {{ error }}
+                </p>
+            </div>
 
             <button
                 type="button"
                 @click="storeTask"
-                disabled
-                title="This feature is under development"
             >
                 Save task
             </button>
@@ -49,9 +74,11 @@ export default {
     name: 'tasks',
     data() {
         return {
-            name,
+            selectedProject: '',
+            name: '',
+            dueDate: '',
             projects: [],
-            selectedProject: ''
+            errors: []
         };
     },
     mounted() {
@@ -68,7 +95,21 @@ export default {
                 });
         },
         storeTask() {
-            // TODO: Add storing logic
+            const data = {
+                project_id: this.selectedProject,
+                name: this.name,
+                due_date: this.dueDate
+            };
+
+            axios.post('/tasks', data)
+                .then(() => {
+                    this.errors = [];
+                    alert('The task was successfully created.');
+                    this.$router.push({ path: '/reports' });
+                })
+                .catch(error => {
+                    this.errors = error.response.data.errors;
+                });
         }
     }
 }

--- a/resources/js/components/Tasks.vue
+++ b/resources/js/components/Tasks.vue
@@ -91,7 +91,8 @@ export default {
                     this.projects = response.data.data;
                 })
                 .catch(error => {
-                    console.error("There was an error fetching the projects data:", error);
+                    // TODO: this must be better handled
+                    console.error('There was an error fetching the projects data:', error);
                 });
         },
         storeTask() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ Route::get('/', function () {
 Route::get('/projects', [ProjectController::class, 'index'])->name('project.index');
 Route::post('/projects', [ProjectController::class, 'store'])->name('project.store');
 Route::put('/projects/{project}', [ProjectController::class, 'update'])->name('project.update');
+Route::delete('/projects/{project}', [ProjectController::class, 'destroy'])->name('project.destroy');
 
 Route::post('/tasks', [TaskController::class, 'store'])->name('task.store');
 Route::put('/tasks/{task}', [TaskController::class, 'update'])->name('task.update');


### PR DESCRIPTION
This PR introduces the following changes:

1. Laravel
    - New route for destroying projects
    - Implemented the destroy method in ProjectController to handle the deletion logic
    - Add cascade on delete in tasks migration
2. Vue
    - Fix project storing logic
    - Fix task storing logic